### PR TITLE
Update Odin version in Dockerfile to 2026-07a to match Odin repo.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ODIN_REF=dev-2026-05
+ARG ODIN_REF=dev-2026-07a
 ARG ARCH=amd64
 ARG TARBALL="odin-linux-${ARCH}-${ODIN_REF}.tar.gz"
 ARG URL="https://github.com/odin-lang/Odin/releases/download/${ODIN_REF}/${TARBALL}"


### PR DESCRIPTION
Updated the odin test runner Dockerfile to use Odin version 2026-07a and match the main Odin repo (after Odin main repo exercism/odin#203 merge).
The Dockerfile is already using Ubuntu 26.04 (compatible with PR #203 from the main repo).
